### PR TITLE
Church basics

### DIFF
--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -4,6 +4,10 @@ import org.scalatest._
 
 class ChurchBasics extends FlatSpec with Matchers {
 
+  /* Church Encoding */
+
+  // Booleans
+
   trait Bool {
     def apply[A](t: A, f: A): A
   }
@@ -26,6 +30,10 @@ class ChurchBasics extends FlatSpec with Matchers {
       def apply[A](t: A, f: A): A = b1(t, b2(t, f))
     }
 
+    def negate(b: Bool): Bool = new Bool {
+      def apply[A](t: A, f: A): A = b(f, t)
+    }
+
     def _if[A](b: Bool)(_then: A, _else: A): A = b(_then, _else)
   }
 
@@ -42,7 +50,78 @@ class ChurchBasics extends FlatSpec with Matchers {
     or(False, True)  (true, false) shouldBe true
     or(True,  True)  (true, false) shouldBe true
 
-    _if(True)(_then = "hello", _else = "world") shouldBe "hello"
-    _if(False)(_then = "hello", _else = "world") shouldBe "world"
+    _if(True)  (_then = "hello", _else = "world") shouldBe "hello"
+    _if(False) (_then = "hello", _else = "world") shouldBe "world"
+  }
+
+  // Naturals
+
+  trait Nat {
+    def apply[A](zero: A, succ: A => A): A
+  }
+
+  object Zero extends Nat {
+    def apply[A](zero: A, succ: A => A): A = zero
+  }
+
+  object One extends Nat {
+    def apply[A](zero: A, succ: A => A): A = succ(zero)
+  }
+
+  object Two extends Nat {
+    def apply[A](zero: A, succ: A => A): A = succ(succ(zero))
+  }
+
+  object Nat {
+    import Bool.negate
+
+    def add(n1: Nat, n2: Nat): Nat = new Nat {
+      def apply[A](zero: A, succ: A => A): A = n2(n1(zero, succ), succ)
+    }
+
+    def isEven(n: Nat): Bool = n(True, negate)
+
+    def isOdd(n: Nat): Bool = negate(isEven(n))
+  }
+
+  "Nat expressions" should "work" in {
+    import Nat._
+
+    isEven(Zero) (true, false) shouldBe true
+    isEven(One)  (true, false) shouldBe false
+    isEven(Two)  (true, false) shouldBe true
+
+    isOdd(Zero)  (true, false) shouldBe false
+    isOdd(One)   (true, false) shouldBe true
+    isOdd(Two)   (true, false) shouldBe false
+
+    isEven(add(Zero, Zero)) (true, false) shouldBe true
+    isEven(add(Zero, One))  (true, false) shouldBe false
+    isEven(add(One,  Zero)) (true, false) shouldBe false
+    isEven(add(One,  One))  (true, false) shouldBe true
+    isEven(add(One,  Two))  (true, false) shouldBe false
+    isEven(add(Two,  One))  (true, false) shouldBe false
+    isEven(add(Two,  Two))  (true, false) shouldBe true
+  }
+
+  // Lists
+
+  trait IntList {
+    def apply[A](nil: A, cons: (Int, A) => A): A
+  }
+
+  object Nil extends IntList {
+    def apply[A](nil: A, cons: (Int, A) => A): A = nil
+  }
+
+  case class Cons(h: Int, t: IntList) extends IntList {
+    def apply[A](nil: A, cons: (Int, A) => A): A = cons(h, t(nil, cons))
+  }
+
+  object IntList {
+
+    def concat(l1: IntList, l2: IntList): IntList = new IntList {
+      def apply[A](nil: A, cons: (Int, A) => A): A = l1(l2(nil, cons), cons)
+    }
   }
 }

--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -4,9 +4,11 @@ import org.scalatest._
 
 class ChurchBasics extends FlatSpec with Matchers {
 
-  /* Church Encoding */
+  /*************************************************************/
+  /* 1. Non-Recursive datatypes: same Church & Scott Encodings */
+  /*************************************************************/
 
-  // Booleans
+  // 1.1. Booleans
 
   trait Bool {
     def apply[A](t: A, f: A): A
@@ -48,7 +50,114 @@ class ChurchBasics extends FlatSpec with Matchers {
     _if(False) (_then = "hello", _else = "world") shouldBe "world"
   }
 
-  // Naturals
+  // 1.2. Tuples
+
+  trait Tuple[B, C] {
+    def apply[A](both: (B, C) => A): A
+  }
+
+  case class StringIntTuple(s: String, i: Int) extends Tuple[String, Int] {
+    def apply[A](both: (String, Int) => A): A = both(s, i)
+  }
+
+  object Tuple {
+
+    def fst[A, B](t: Tuple[A, B]): A = t((a, _) => a)
+
+    def snd[A, B](t: Tuple[A, B]): B = t((_, b) => b)
+
+    def swap[B, C](t: Tuple[B, C]): Tuple[C, B] = new Tuple[C, B] {
+      def apply[A](both: (C, B) => A): A = t((b, c) => both(c, b))
+    }
+  }
+
+  "Tuple expressions" should "work" in {
+    import Tuple._
+
+    val t = StringIntTuple("text", 0)
+
+    fst(t) shouldBe "text"
+    snd(t) shouldBe 0
+    swap(t) ((i, s) => s"$i -> $s") shouldBe "0 -> text"
+  }
+
+  // 1.3. Temperatures
+
+  trait Temperature {
+    def apply[A](f: Int => A, c: Int => A): A
+  }
+
+  case class Fahrenheit(i: Int) extends Temperature {
+    def apply[A](f: Int => A, c: Int => A): A = f(i)
+  }
+
+  case class Celsius(i: Int) extends Temperature {
+    def apply[A](f: Int => A, c: Int => A): A = c(i)
+  }
+
+  object Temperature {
+    def warm(t: Temperature): Boolean = t[Boolean](_ > 90, _ > 30)
+  }
+
+  "Temperature expressions" should "work" in {
+    import Temperature._
+
+    val t1: Temperature = Fahrenheit(40)
+    val t2: Temperature = Celsius(40)
+
+    warm(t1) shouldBe false
+    warm(t2) shouldBe true
+  }
+
+  /**************************/
+  /* 2. Recursive datatypes */
+  /**************************/
+
+  // 2.1. Naturals
+
+  // 2.1.1. Scott Encoding
+
+  trait SNat {
+    def apply[A](zero: A, succ: SNat => A): A
+  }
+
+  case object SZero extends SNat {
+    def apply[A](zero: A, succ: SNat => A): A = zero
+  }
+
+  case object SOne extends SNat {
+    def apply[A](zero: A, succ: SNat => A): A = succ(SZero)
+  }
+
+  case class SSucc(n: SNat) extends SNat {
+    def apply[A](zero: A, succ: SNat => A): A = succ(n)
+  }
+
+  object SNat {
+
+    def add(n: SNat, m: SNat): SNat = n(m, add(_, m))
+
+    // O(1) complexity
+    def pred(n: SNat): SNat = n(SZero, identity)
+
+    // aka. church to scott...
+    def foldNat[A](zero: A, succ: A => A): SNat => A =
+      _(zero, n => succ(foldNat(zero, succ)(n)))
+
+    def toChurch: SNat => Nat = foldNat(Zero, Succ)
+  }
+
+  "Scott's Nat expressions" should "work" in {
+    import SNat._
+
+    pred(SOne)[Int](0, _ => 1) shouldBe 0
+    pred(SSucc(SOne))[Int](0, _ => 1) shouldBe 1
+
+    add(SZero, SZero)(0, _ => 1) shouldBe 0
+    add(SZero, SOne)(0, _ => 1) shouldBe 1
+  }
+
+  // 2.1.2. Church Encoding
 
   trait Nat {
     def apply[A](zero: A, succ: A => A): A
@@ -78,9 +187,15 @@ class ChurchBasics extends FlatSpec with Matchers {
     def isEven(n: Nat): Bool = n(True, negate)
 
     def isOdd(n: Nat): Bool = negate(isEven(n))
+
+    // It takes `O(n)` to get the predecessor!
+    def pred(n: Nat): Nat =
+      n[(Nat, Nat)]((Zero, Zero), { case (_, x) => (x, Succ(x)) })._1
+
+    def toScott: Nat => SNat = _[SNat](SZero, SSucc)
   }
 
-  "Nat expressions" should "work" in {
+  "Church's Nat expressions" should "work" in {
     import Nat._
 
     isEven(Zero)      (true, false) shouldBe true
@@ -98,9 +213,88 @@ class ChurchBasics extends FlatSpec with Matchers {
     isEven(mul(Zero, Zero))           (true, false) shouldBe true
     isEven(mul(Zero, One))            (true, false) shouldBe true
     isEven(mul(Succ(One), Succ(One))) (true, false) shouldBe true
+
+    pred(Zero)[Int](0, _ + 1)            shouldBe 0 // XXX: weird behaviour!
+    pred(One)[Int](0, _ + 1)             shouldBe 0
+    pred(Succ(One))[Int](0, _ + 1)       shouldBe 1
+    pred(Succ(Succ(One)))[Int](0, _ + 1) shouldBe 2
   }
 
-  // Lists
+  // 2.1.3. Parigot Encoding
+
+  trait PNat {
+    def apply[A](zero: A, succ: (PNat, A) => A): A
+  }
+
+  case object PZero extends PNat {
+    def apply[A](zero: A, succ: (PNat, A) => A): A = zero
+  }
+
+  case object POne extends PNat {
+    def apply[A](zero: A, succ: (PNat, A) => A): A = succ(PZero, zero)
+  }
+
+  case class PSucc(n: PNat) extends PNat {
+    def apply[A](zero: A, succ: (PNat, A) => A): A = succ(n, n(zero, succ))
+  }
+
+  object PNat {
+
+    def add(n: PNat, m: PNat): PNat = n[PNat](m, (p, a) => PSucc(a))
+
+    def pred(n: PNat): PNat = n[PNat](PZero, (p, _) => p)
+  }
+
+  "Parigot's Nat expressions" should "work" in {
+    import PNat._
+
+    pred(POne)[Int](0, (_, i) => i) shouldBe 0
+    pred(PSucc(POne))[Int](0, (_, i) => i + 1) shouldBe 1
+
+    add(PZero, PZero)[Int](0, (_, i) => i) shouldBe 0
+    add(PZero, POne)[Int](0, (_, i) => i + 1) shouldBe 1
+    add(POne, POne)[Int](0, (_, i) => i + 1) shouldBe 2
+  }
+
+  // 2.2. Lists
+
+  // 2.2.1. Scott Encoding
+
+  trait SIntList {
+    def apply[A](nil: => A, cons: (Int, SIntList) => A): A
+  }
+
+  object SNil extends SIntList {
+    def apply[A](nil: => A, cons: (Int, SIntList) => A): A = nil
+  }
+
+  case class SCons(h: Int, t: SIntList) extends SIntList {
+    def apply[A](nil: => A, cons: (Int, SIntList) => A): A = cons(h, t)
+  }
+
+  object SIntList {
+
+    // O(1) complexity
+    def head(l: SIntList): Int =
+      l(throw new Error("Nil.head"), (i, _) => i)
+
+    // O(1) complexity
+    def tail(l: SIntList): SIntList =
+      l(throw new Error("Nil.tail"), (_, t) => t)
+
+    def foldIntList[A](nil: A, cons: (Int, A) => A): SIntList => A =
+      _(nil, (i, xs) => cons(i, foldIntList(nil, cons)(xs)))
+  }
+
+  "Scott's Lists expressions" should "work" in {
+    import SIntList._
+
+    head(SCons(1, SNil)) shouldBe 1
+    head(SCons(2, SCons(1, SNil))) shouldBe 2
+    head(tail(SCons(2, SCons(1, SNil)))) shouldBe 1
+  }
+
+  // 2.2.2. Church Encoding
 
   trait IntList {
     def apply[A](nil: A, cons: (Int, A) => A): A

--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -22,17 +22,11 @@ class ChurchBasics extends FlatSpec with Matchers {
 
   object Bool {
 
-    def and(b1: Bool, b2: Bool): Bool = new Bool {
-      def apply[A](t: A, f: A): A = b1(b2(t, f), f)
-    }
+    def and(b1: Bool, b2: Bool): Bool = b1(b2(True, False), False)
 
-    def or(b1: Bool, b2: Bool): Bool = new Bool {
-      def apply[A](t: A, f: A): A = b1(t, b2(t, f))
-    }
+    def or(b1: Bool, b2: Bool): Bool = b1(True, b2(True, False))
 
-    def negate(b: Bool): Bool = new Bool {
-      def apply[A](t: A, f: A): A = b(f, t)
-    }
+    def negate(b: Bool): Bool = b(False, True)
 
     def _if[A](b: Bool)(_then: A, _else: A): A = b(_then, _else)
   }
@@ -121,10 +115,7 @@ class ChurchBasics extends FlatSpec with Matchers {
   }
 
   object IntList {
-
-    def concat(l1: IntList, l2: IntList): IntList = new IntList {
-      def apply[A](nil: A, cons: (Int, A) => A): A = l1(l2(nil, cons), cons)
-    }
+    def concat(l1: IntList, l2: IntList): IntList = l1(l2, Cons)
   }
 
   "Lists expressions" should "work" in {

--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -124,4 +124,12 @@ class ChurchBasics extends FlatSpec with Matchers {
       def apply[A](nil: A, cons: (Int, A) => A): A = l1(l2(nil, cons), cons)
     }
   }
+
+  "Lists expressions" should "work" in {
+    import IntList._
+
+    concat(Nil, Nil).apply[Int](0, _ + _) shouldBe 0
+    concat(Cons(1, Nil), Nil).apply[Int](0, _ + _) shouldBe 1
+    concat(Cons(1, Nil), Cons(2, Nil)).apply[Int](0, _ + _) shouldBe 3
+  }
 }

--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -1,0 +1,48 @@
+package org.hablapps.gist
+
+import org.scalatest._
+
+class ChurchBasics extends FlatSpec with Matchers {
+
+  trait Bool {
+    def apply[A](t: A, f: A): A
+  }
+
+  object True extends Bool {
+    def apply[A](t: A, f: A): A = t
+  }
+
+  object False extends Bool {
+    def apply[A](t: A, f: A): A = f
+  }
+
+  object Bool {
+
+    def and(b1: Bool, b2: Bool): Bool = new Bool {
+      def apply[A](t: A, f: A): A = b1(b2(t, f), f)
+    }
+
+    def or(b1: Bool, b2: Bool): Bool = new Bool {
+      def apply[A](t: A, f: A): A = b1(t, b2(t, f))
+    }
+
+    def _if[A](b: Bool)(_then: A, _else: A): A = b(_then, _else)
+  }
+
+  "Bool expressions" should "work" in {
+    import Bool._
+
+    and(False, False) (true, false) shouldBe false
+    and(True,  False) (true, false) shouldBe false
+    and(False, True)  (true, false) shouldBe false
+    and(True,  True)  (true, false) shouldBe true
+
+    or(False, False) (true, false) shouldBe false
+    or(True,  False) (true, false) shouldBe true
+    or(False, True)  (true, false) shouldBe true
+    or(True,  True)  (true, false) shouldBe true
+
+    _if(True)(_then = "hello", _else = "world") shouldBe "hello"
+    _if(False)(_then = "hello", _else = "world") shouldBe "world"
+  }
+}

--- a/src/test/scala/ChurchBasics.scala
+++ b/src/test/scala/ChurchBasics.scala
@@ -65,19 +65,21 @@ class ChurchBasics extends FlatSpec with Matchers {
   }
 
   object One extends Nat {
-    def apply[A](zero: A, succ: A => A): A = succ(zero)
+    def apply[A](zero: A, succ: A => A): A = succ(Zero[A](zero, succ))
   }
 
-  object Two extends Nat {
-    def apply[A](zero: A, succ: A => A): A = succ(succ(zero))
+  case class Succ(n: Nat) extends Nat {
+    def apply[A](zero: A, succ: A => A): A = succ(n(zero, succ))
   }
 
   object Nat {
     import Bool.negate
 
-    def add(n1: Nat, n2: Nat): Nat = new Nat {
-      def apply[A](zero: A, succ: A => A): A = n2(n1(zero, succ), succ)
-    }
+    def add(n: Nat, m: Nat): Nat = n(m, Succ)
+
+    def mul(n: Nat, m: Nat): Nat = n[Nat](Zero, add(m, _))
+
+    def exp(n: Nat, m: Nat): Nat = n[Nat](One, mul(m, _))
 
     def isEven(n: Nat): Bool = n(True, negate)
 
@@ -87,21 +89,21 @@ class ChurchBasics extends FlatSpec with Matchers {
   "Nat expressions" should "work" in {
     import Nat._
 
-    isEven(Zero) (true, false) shouldBe true
-    isEven(One)  (true, false) shouldBe false
-    isEven(Two)  (true, false) shouldBe true
+    isEven(Zero)      (true, false) shouldBe true
+    isEven(One)       (true, false) shouldBe false
+    isEven(Succ(One)) (true, false) shouldBe true
 
-    isOdd(Zero)  (true, false) shouldBe false
-    isOdd(One)   (true, false) shouldBe true
-    isOdd(Two)   (true, false) shouldBe false
+    isOdd(Zero) (true, false) shouldBe false
+    isOdd(One)  (true, false) shouldBe true
 
     isEven(add(Zero, Zero)) (true, false) shouldBe true
     isEven(add(Zero, One))  (true, false) shouldBe false
     isEven(add(One,  Zero)) (true, false) shouldBe false
     isEven(add(One,  One))  (true, false) shouldBe true
-    isEven(add(One,  Two))  (true, false) shouldBe false
-    isEven(add(Two,  One))  (true, false) shouldBe false
-    isEven(add(Two,  Two))  (true, false) shouldBe true
+
+    isEven(mul(Zero, Zero))           (true, false) shouldBe true
+    isEven(mul(Zero, One))            (true, false) shouldBe true
+    isEven(mul(Succ(One), Succ(One))) (true, false) shouldBe true
   }
 
   // Lists

--- a/src/test/scala/InitialAlgebras.scala
+++ b/src/test/scala/InitialAlgebras.scala
@@ -4,17 +4,17 @@ package org.hablapps.gist
 The purpose of this gist is explaining the relationships between ADT and Church
 encodings using algebraic concepts. We'll use the familiar domain of arithmetic expressions.
 Essentially, we'll see that given an algebraic theory for arithmetic expressions, ADT
-and Church encodings correspond to initial algebras of that theory, completely equivalent 
-for all purposes (functionally speaking, since they may differ significantly in non-functional 
+and Church encodings correspond to initial algebras of that theory, completely equivalent
+for all purposes (functionally speaking, since they may differ significantly in non-functional
 concerns such as efficiency, modularity, etc.).
 
-We will make reference to these others gists, on ADTs and Church encodings, respectively: 
+We will make reference to these others gists, on ADTs and Church encodings, respectively:
 * https://github.com/hablapps/gist/blob/master/src/test/scala/ADTs.scala
 * https://github.com/hablapps/gist/blob/master/src/test/scala/ChurchEncodings.scala
 
-There are two basic ways of representing algebras in Scala: as functor algebras, 
+There are two basic ways of representing algebras in Scala: as functor algebras,
 and as object algebras. We'll follow the later approach in this gist. For more information on
-object algebras check the following source: 
+object algebras check the following source:
 
 Extensibility for the Masses. Practical Extensibility with Object Algebras
 Bruno C. d. S. Oliveira and William R. Cook
@@ -27,13 +27,16 @@ import org.scalatest._
 class InitialAlgebras extends FlatSpec with Matchers{
 
   /*
-  An algebraic theory is simply a collection of operations that allow us to build 
-  objects according to certain rules. In our case, we want to create arithmetic 
-  expressions. 
+  An algebraic theory is simply a collection of operations that allow us to build
+  objects according to certain rules. In our case, we want to create arithmetic
+  expressions.
 
-  The following trait tells us that we can create arithmetic expressions using the 
-  operations, or constructors, `lit`, `neg` and `add`. Any type `E` for which 
-  we can implement the following trait qualifies as an arithmetic expression. 
+  @jeslg: here, algebraic theory is synonim for typeclass or object algebra
+  interface.
+
+  The following trait tells us that we can create arithmetic expressions using the
+  operations, or constructors, `lit`, `neg` and `add`. Any type `E` for which
+  we can implement the following trait qualifies as an arithmetic expression.
 
   As you can see, object algebras are directly represented by type classes in Scala.
   */
@@ -46,13 +49,13 @@ class InitialAlgebras extends FlatSpec with Matchers{
   object ExprAlg{
 
     // Syntactical helper
-    def apply[E](clit: Int => E, cneg: E => E, cadd: (E,E)=>E): ExprAlg[E] = 
+    def apply[E](clit: Int => E, cneg: E => E, cadd: (E,E)=>E): ExprAlg[E] =
       new ExprAlg[E]{
         def lit(i: Int) = clit(i)
         def neg(e: E) = cneg(e)
         def add(e1: E, e2: E) = cadd(e1,e2)
       }
-    
+
   }
 
   /*
@@ -62,13 +65,13 @@ class InitialAlgebras extends FlatSpec with Matchers{
   */
 
   object Eval{
-  
-    val algebra: ExprAlg[Int] = 
-      ExprAlg(i => i, 
-        i => -i, 
+
+    val algebra: ExprAlg[Int] =
+      ExprAlg(i => i,
+        i => -i,
         (i1,i2) => i1 + i2)
 
-    /* 
+    /*
     Using the algebra, we can create integers as if they were aritmethic expressions
     */
     import algebra._
@@ -76,15 +79,15 @@ class InitialAlgebras extends FlatSpec with Matchers{
     add(lit(1),lit(2)) shouldBe 3
     add(neg(add(neg(lit(1)),lit(2))),lit(3)) shouldBe 2
   }
-    
+
   object Write{
-  
-    val algebra: ExprAlg[String] = 
+
+    val algebra: ExprAlg[String] =
       ExprAlg(i => i.toString,
-        s => s"(-$s)", 
+        s => s"(-$s)",
         (s1,s2) => s"($s1+$s2)")
 
-    /* 
+    /*
     This time, using the algebra we can create strings as if they were aritmethic expressions
     */
     import algebra._
@@ -97,23 +100,23 @@ class InitialAlgebras extends FlatSpec with Matchers{
 
   /*
   Although we have seen that strings and integers "are" arithmetic expressions, since there
-  are expression algebras for them, it seems somewhat odd to say that. Intuitively, 
+  are expression algebras for them, it seems somewhat odd to say that. Intuitively,
   we may rather say that arithmetic expressions can be *interpreted* as strings or integers.
-  From this perspective, expression algebras such as `Eval.algebra` and `Write.algebra` are 
-  the interpreters. 
+  From this perspective, expression algebras such as `Eval.algebra` and `Write.algebra` are
+  the interpreters.
 
   Now, there are interpreters which are special, in the sense that they allow us to create
   arithmetic expressions that are fully general, and apparently free of any particular
-  interpretation. For instance, let's consider an ADT representation of arithmetic expressions. 
+  interpretation. For instance, let's consider an ADT representation of arithmetic expressions.
   We can indeed interpret the expression algebra over the `Expr` ADT.
   */
 
   object ADTAlgebra{
 
-    // The constructors of the ADT are in a one-to-one correspondence with the 
+    // The constructors of the ADT are in a one-to-one correspondence with the
     // algebra operations
     import ADTs.{Lit,Neg,Add,Expr}
-    
+
     val algebra: ExprAlg[Expr] = ExprAlg(Lit, Neg, Add)
 
     // Let's create some arithmetic expressions
@@ -123,29 +126,29 @@ class InitialAlgebras extends FlatSpec with Matchers{
     add(neg(add(neg(lit(1)),lit(2))),lit(3)) shouldBe Add(Neg(Add(Neg(Lit(1)),Lit(2))),Lit(3))
 
   }
-  
+
   /*
   But not only we can understand ADT expressions through the lens of expression algebras.
   More importantly, we can obtain *any* other interpretation from it. Technically,
-  this means that the ADT algebra is initial, i.e. there is an algebra homomorphism (and 
-  only one) from the ADT algebra to any other one. More informally, ADT expressions carry 
-  no particular meaning at all. So, given a particular interpretation (e.g. an algebra 
-  for integers), we can interpret the ADT expression to obtain a value in the domain of 
+  this means that the ADT algebra is initial, i.e. there is an algebra homomorphism (and
+  only one) from the ADT algebra to any other one. More informally, ADT expressions carry
+  no particular meaning at all. So, given a particular interpretation (e.g. an algebra
+  for integers), we can interpret the ADT expression to obtain a value in the domain of
   that interpretation. This is what the `fold` function accomplishes. Taking this into
-  account, we can say that initial domains are canonical ways of representing algebraic 
+  account, we can say that initial domains are canonical ways of representing algebraic
   expressions.
 
-  In sum, an initial algebra is an algebra `Alg[I]` such that for any other possible 
+  In sum, an initial algebra is an algebra `Alg[I]` such that for any other possible
   algebra `Alg[A]`, we can interpret `I` as `A`:
   */
 
-  trait InitialAlgebra[I, Alg[_]]{ 
+  trait InitialAlgebra[I, Alg[_]]{
     def algebra: Alg[I]
     def fold[A](alg: Alg[A]): I => A
   }
 
   /*
-  We already implemented `fold` for the ADT representation, so we can easily check that 
+  We already implemented `fold` for the ADT representation, so we can easily check that
   ADT expressions make up an initial algebra.
   */
   object ADTInitial{
@@ -162,10 +165,10 @@ class InitialAlgebras extends FlatSpec with Matchers{
     // the corresponding algebras (i.e. interpreters)
     import initial._, algebra._
 
-    val e1: Expr = add(lit(1),lit(2)) // we create ADT expressions using 
+    val e1: Expr = add(lit(1),lit(2)) // we create ADT expressions using
                                       // the "smart" constructors of the
                                       // algebra, rather than the ADT constructors.
-    
+
     fold(Eval.algebra)(e1) shouldBe 3
     fold(Write.algebra)(e1) shouldBe "(1+2)"
   }
@@ -173,24 +176,24 @@ class InitialAlgebras extends FlatSpec with Matchers{
   "ADTInitial" should "work" in ADTInitial
 
   /*
-  Besides ADT representations, in which other ways can we represent expressions in a 
+  Besides ADT representations, in which other ways can we represent expressions in a
   canonical way? In other words, how can we construct other initial algebras? There are at
-  least two other ways: one uses fixed points of functors, and the other one Church encodings. 
+  least two other ways: one uses fixed points of functors, and the other one Church encodings.
   We will review this second one now.
 
   To motivate Church encodings, note that we have being using two particular expressions
-  throughout this gist: 
+  throughout this gist:
 
-      add(lit(1),lit(2)), and 
+      add(lit(1),lit(2)), and
       add(neg(add(neg(lit(1)),lit(2))),lit(3))
 
-  These expressions were written using the constructors `add`, `lit` and `neg` of particular 
-  expression algebras (`Eval.algebra`, `Write.algebra` or `ADTAlgebra.algebra`). Can we write 
+  These expressions were written using the constructors `add`, `lit` and `neg` of particular
+  expression algebras (`Eval.algebra`, `Write.algebra` or `ADTAlgebra.algebra`). Can we write
   these expressions just once, for any possible algebra? Yes, we can!
   */
   object TowardsChurch{
 
-    // We simply build upon a generic algebra, instead of a particular one. 
+    // We simply build upon a generic algebra, instead of a particular one.
     def e0[E](alg: ExprAlg[E]): E = {
       import alg._
       add(lit(1),lit(2))
@@ -215,8 +218,8 @@ class InitialAlgebras extends FlatSpec with Matchers{
 
   /*
   Now, please note the close similarity between the representation of arithmetic expressions
-  using ad-hoc polymorphic functions such as `e0` and `e1`, and the Church encoding of 
-  arithmetic expressions: 
+  using ad-hoc polymorphic functions such as `e0` and `e1`, and the Church encoding of
+  arithmetic expressions:
 
   https://github.com/hablapps/gist/blob/master/src/test/scala/ChurchEncodings.scala#L45
 
@@ -225,8 +228,8 @@ class InitialAlgebras extends FlatSpec with Matchers{
   identical to the ones that we wrote before, `e0` and `e1`, the difference just being that
   the constructors in these later functions are packaged within an algebra.
 
-  It's actually very easy to come up with the proof that Church encodings are initial 
-  algebras. 
+  It's actually very easy to come up with the proof that Church encodings are initial
+  algebras.
   */
 
   object ChurchInitial{
@@ -244,6 +247,10 @@ class InitialAlgebras extends FlatSpec with Matchers{
     Using the Church algebra we can write the expressions `e0` and `e1` step-by-step,
     instead of performing a single instantiation (not saying that this is good, simply
     that you can).
+
+    @jeslg: step-by-step means that `add`, `lit` and `neg` are creating
+    intermediate expressions (reified by `Expr`)
+
     */
 
     import initial._, algebra._
@@ -252,19 +259,19 @@ class InitialAlgebras extends FlatSpec with Matchers{
     val e1: Expr = add(neg(add(neg(lit(1)),lit(2))),lit(3))
 
     /*
-    Being a canonical domain, we can interpret Church expressions as integers, string, 
-    or even ADT expressions (another canonical domain), using their corresponding 
+    Being a canonical domain, we can interpret Church expressions as integers, string,
+    or even ADT expressions (another canonical domain), using their corresponding
     interpreters.
     */
     import ADTs.{Lit, Add, Neg}
 
     fold(ADTAlgebra.algebra)(e0) shouldBe Add(Lit(1),Lit(2))
     fold(Eval.algebra)(e0) shouldBe 3
-    fold(Write.algebra)(e0) shouldBe "(1+2)"    
+    fold(Write.algebra)(e0) shouldBe "(1+2)"
   }
 
   "Church Initial" should "work" in ChurchInitial
-  
+
 }
 
 object InitialAlgebras extends InitialAlgebras

--- a/src/test/scala/InitialAlgebras.scala
+++ b/src/test/scala/InitialAlgebras.scala
@@ -31,9 +31,6 @@ class InitialAlgebras extends FlatSpec with Matchers{
   objects according to certain rules. In our case, we want to create arithmetic
   expressions.
 
-  @jeslg: here, algebraic theory is synonim for typeclass or object algebra
-  interface.
-
   The following trait tells us that we can create arithmetic expressions using the
   operations, or constructors, `lit`, `neg` and `add`. Any type `E` for which
   we can implement the following trait qualifies as an arithmetic expression.
@@ -247,10 +244,6 @@ class InitialAlgebras extends FlatSpec with Matchers{
     Using the Church algebra we can write the expressions `e0` and `e1` step-by-step,
     instead of performing a single instantiation (not saying that this is good, simply
     that you can).
-
-    @jeslg: step-by-step means that `add`, `lit` and `neg` are creating
-    intermediate expressions (reified by `Expr`)
-
     */
 
     import initial._, algebra._

--- a/src/test/scala/LambdaBasics.scala
+++ b/src/test/scala/LambdaBasics.scala
@@ -2,7 +2,7 @@ package org.hablapps.gist
 
 import org.scalatest._
 
-class ChurchBasics extends FlatSpec with Matchers {
+class LambdaBasics extends FlatSpec with Matchers {
 
   /*************************************************************/
   /* 1. Non-Recursive datatypes: same Church & Scott Encodings */

--- a/src/test/scala/NaturalEncodings.scala
+++ b/src/test/scala/NaturalEncodings.scala
@@ -27,6 +27,7 @@ class NaturalEncodings extends FlatSpec with Matchers {
     def apply[E](z: E, f: E => E): NatAlg[E] = NatCases[E, E](z, f)
   }
 
+  // Church Encoding
   trait CNat {
     def apply[A](alg: NatAlg[A]): A
   }
@@ -64,6 +65,7 @@ class NaturalEncodings extends FlatSpec with Matchers {
     fold(eval)(add(succ(zero), succ(zero))) shouldBe 2
   }
 
+  // Scott Encoding
   trait SNat {
     def apply[A](alg: NatCases[SNat, A]): A
   }
@@ -102,6 +104,7 @@ class NaturalEncodings extends FlatSpec with Matchers {
     fold(eval)(add(succ(zero), succ(zero))) shouldBe 2
   }
 
+  // Parigot Encoding
   trait PNat {
     def apply[A](alg: NatCases[(PNat, A), A]): A
   }

--- a/src/test/scala/NaturalEncodings.scala
+++ b/src/test/scala/NaturalEncodings.scala
@@ -1,0 +1,164 @@
+package org.hablapps.gist
+
+import org.scalatest._
+
+class NaturalEncodings extends FlatSpec with Matchers {
+
+  // Quasi Algebra for Naturals
+  trait NatQAlg[S, E] {
+    def zero: E
+    def succ(s: S): E
+  }
+
+  object NatQAlg {
+
+    def apply[S, E](z: E, f: S => E): NatQAlg[S, E] = new NatQAlg[S, E] {
+      def zero: E = z
+      def succ(s: S): E = f(s)
+    }
+
+    trait Syntax {
+      def zero[S, E](implicit ev: NatQAlg[S, E]): E = ev.zero
+      def succ[S, E](s: S)(implicit ev: NatQAlg[S, E]): E = ev.succ(s)
+    }
+
+    object syntax extends Syntax
+  }
+
+  type NatAlg[E] = NatQAlg[E, E]
+
+  object NatAlg {
+    def apply[E](z: E, f: E => E): NatAlg[E] = NatQAlg[E, E](z, f)
+  }
+
+  trait CNat {
+    def apply[A](alg: NatAlg[A]): A
+  }
+
+  object CNat {
+
+    val initial: NatAlg[CNat] = NatAlg(
+      new CNat {
+        def apply[A](alg: NatAlg[A]): A = alg.zero
+      },
+      s => new CNat {
+        def apply[A](alg: NatAlg[A]): A = alg.succ(s(alg))
+      })
+
+    val eval: NatAlg[Int] = NatAlg(0, _ + 1)
+
+    object operator {
+      def add(n: CNat, m: CNat): CNat = n(NatAlg(m, initial.succ))
+    }
+  }
+
+  "Church's Nat algebra" should "work" in {
+    import CNat._, initial._, operator._
+
+    add(zero, zero)(eval) shouldBe 0
+    add(zero, succ(zero))(eval) shouldBe 1
+    add(succ(zero), succ(zero))(eval) shouldBe 2
+  }
+
+  trait SNat {
+    def apply[A](alg: NatQAlg[SNat, A]): A
+  }
+
+  object SNat {
+
+    val qinitial: NatQAlg[SNat, SNat] = new NatQAlg[SNat, SNat] {
+
+      def zero: SNat = new SNat {
+        def apply[A](alg: NatQAlg[SNat, A]): A = alg.zero
+      }
+
+      def succ(s: SNat): SNat = new SNat {
+        def apply[A](alg: NatQAlg[SNat, A]): A = alg.succ(s)
+      }
+    }
+
+    val eval: NatQAlg[SNat, Int] = NatQAlg[SNat, Int](0, s => s(eval) + 1)
+
+    object operator {
+      def add(n: SNat, m: SNat): SNat =
+        n(NatQAlg(m, p => qinitial.succ(add(p, m))))
+    }
+  }
+
+  "Scott's Nat algebra" should "work" in {
+    import SNat._, qinitial._, operator._
+
+    add(zero, zero)(eval) shouldBe 0
+    add(zero, succ(zero))(eval) shouldBe 1
+    add(succ(zero), zero)(eval) shouldBe 1
+    add(succ(zero), succ(zero))(eval) shouldBe 2
+  }
+
+  trait PNat {
+    def apply[A](alg: NatQAlg[(PNat, A), A]): A
+  }
+
+  object PNat {
+
+    val qinitial = new NatQAlg[(PNat, PNat), PNat] {
+
+      def zero: PNat = new PNat {
+        def apply[A](alg: NatQAlg[(PNat, A), A]): A = alg.zero
+      }
+
+      def succ(s: (PNat, PNat)): PNat = new PNat {
+        def apply[A](alg: NatQAlg[(PNat, A), A]): A =
+          // XXX: `(x, y).map(f)` with cats, where are you?
+          alg.succ(s match { case (x, y) => (x, y(alg)) })
+      }
+    }
+
+    val eval: NatQAlg[(PNat, Int), Int] =
+      NatQAlg[(PNat, Int), Int](0, { case (_, i) => i + 1 })
+
+    object operator {
+      def add(n: PNat, m: PNat): PNat =
+        n(NatQAlg[(PNat, PNat), PNat](m, {
+          case (p, a) => qinitial.succ(p, a)
+        }))
+    }
+  }
+
+  "Parigot's Nat algebra" should "work" in {
+    import PNat._, qinitial._, operator._
+
+    // These expressions make no sense, since `succ` requires a tuple as input
+    // `(PNat, PNat)`
+
+    // add(zero, zero)(eval) shouldBe 0
+    // add(zero, succ(zero))(eval) shouldBe 1
+    // add(succ(zero), zero)(eval) shouldBe 1
+    // add(succ(zero), succ(zero))(eval) shouldBe 2
+
+    // We "solve" this limitation replacing `succ` with the following method.
+    def succ2(prev: PNat): PNat = succ((prev, prev))
+
+    add(zero, zero)(eval) shouldBe 0
+    add(zero, succ2(zero))(eval) shouldBe 1
+    add(succ2(zero), zero)(eval) shouldBe 1
+    add(succ2(zero), succ2(zero))(eval) shouldBe 2
+    add(succ2(succ2(zero)), succ2(zero))(eval) shouldBe 3
+  }
+
+  // What about generic expressions?
+
+  import NatQAlg.syntax._
+
+  def zeroE[S, E](implicit ev: NatQAlg[S, E]): E = zero
+
+  // XXX: Ops! zero's type is E, but `succ` is requiring S! In fact, what I was
+  // trying to do was to force a Scott representation into a typeclass
+  // expression (which we know it's almost Church encoding) That's why the ideal
+  // of a generic expression is utopic.
+
+  // def oneE[S, E](implicit ev: NatQAlg[S, E]): E = succ(zero)
+
+  // => Well, it seems to be ¿impossible? to have a unique expression to be
+  // shared by the different encodings. So what's the point of keeping `NatQAlg`
+  // (disregarding the didactic comparision)?
+}


### PR DESCRIPTION
Un "script" sencillo con diferentes _datatypes_ representados en _Church_, _Scott_ y _Parigot_ encoding. Hay bastantes detalles por pulir (mejorar tests, comparación de eficiencia entre representaciones sistemática...) pero creo que el principal objetivo, que era plasmar las diferencias de formato entre las codificaciones, queda bien recogido.

\cc @jserranohidalgo @javierfs89 
