### PR TITLE
Updated dependencies and tweaked gitignore rules…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
-target/*
-project/target/*
-project/project/target/*
+*.iml
+.idea/
+build/
+project/
+target/
+

--- a/build.sbt
+++ b/build.sbt
@@ -8,17 +8,17 @@ scalaBinaryVersion := "2.11"
 
 organization := "org.hablapps"
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.0")
 
 resolvers ++= Seq(
   "Speech repo - releases" at "http://repo.hablapps.com/releases")
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats" % "0.7.0",
+  "org.typelevel" %% "cats" % "0.7.2",
   "org.scalaz" %% "scalaz-core" % "7.3.0-M4-HABLAPPS",
-  "org.scalatest" %% "scalatest" % "2.2.6",
-  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.10",
-  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.10",
+  "org.scalatest" %% "scalatest" % "3.0.0",
+  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.4.11",
   "com.lihaoyi" %% "sourcecode" % "0.1.2"
 )
 


### PR DESCRIPTION
…  to exclude generated / unneeded files from builds / IDEs.

I tried to import / build the repo on IntelliJ IDEA and i run into some issues. I have updated the dependencies in the build.sbt and now almost everything is working (only 2 tests fail due to implicit resolution, but that may be the case also on the current master branch). Also, i do not know if the dependency for scalaz-core 7.3.0-M4-HABLAPPS had something not in the standard scalaz, but it was not available on maven central and it seemed to work fine after switching to public version 7.3.0-M5.
